### PR TITLE
Add timeout on running jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION          ?= $(shell git describe --tags --always --dirty)
 TAG              ?= $(VERSION)
 GITHEAD          = $(shell git rev-parse --short HEAD)
 GITURL           = $(shell git config --get remote.origin.url)
-GITSTATU         = $(shell git status --porcelain || echo "no changes")
+GITSTATUS         = $(shell git status --porcelain || echo "no changes")
 
 default: docker
 

--- a/cleaner.py
+++ b/cleaner.py
@@ -40,7 +40,10 @@ for job in pykube.Job.objects(api, namespace=pykube.all):
             continue
     start_time = parse_time(job.obj['status'].get('startTime'))
     seconds_since_start = now - start_time
-    timeout_override = job.obj['metadata'].get('annotations').get('cleanup-timeout')
+    annotations = job.obj['metadata'].get('annotations')
+    if annotations is None:
+        continue
+    timeout_override = annotations.get('cleanup-timeout')
     timeout_jobs = int(timeout_override) if timeout_override else args.timeout_seconds
     #Check whether timeout is activated. Always obeys the annotation on the job
     if timeout_jobs < 0:

--- a/cleaner.py
+++ b/cleaner.py
@@ -40,6 +40,9 @@ for job in pykube.Job.objects(api, namespace=pykube.all):
 for pod in pykube.Pod.objects(api, namespace=pykube.all):
     if pod.obj['status'].get('phase') in ('Succeeded', 'Failed'):
         seconds_since_completion = 0
+        if pod.obj['status'].get('containerStatuses') is None:
+            print("Warning: Skipping pod without containers ({})".format(pod.obj['metadata'].get('name')))
+            continue
         for container in pod.obj['status'].get('containerStatuses'):
             if 'terminated' in container['state']:
                 state = container['state']


### PR DESCRIPTION
We have the problem of jobs not succeeding and running eternally. Therefore we introduced a hard cut-off with `--timeout-seconds` which is disabled by default. This can be overridden by setting `cleanup-timeout` in seconds as an annotation on the job.

This is a follow-up of the last pull-request so contains the same commits also. I can remove the other pull-request if this one is accepted.